### PR TITLE
Fix modal loop stuck at GetMessage

### DIFF
--- a/ui/any_globals.go
+++ b/ui/any_globals.go
@@ -223,6 +223,10 @@ func _RunModalLoop(hWnd win.HWND) {
 	pMsg := (*win.MSG)(unsafe.Pointer(&block[0]))
 
 	for {
+		if hWnd == 0 || !hWnd.IsWindow() {
+			break // our modal was destroyed, terminate loop
+		}
+
 		if res, err := win.GetMessage(pMsg, win.HWND(0), 0, 0); err != nil {
 			panic(err)
 		} else if res == 0 {


### PR DESCRIPTION
In Windows 11, Loop stucks at GetMessage If hWnd.IsWindow() is false.

This commit resolves that issue.

Your patch 8e110a3 works in Windows 10 but not in Windows 11. I tried dig down into windigo and I addressed that is modal loop stucks at GetMessage.

After adding that lines, program works as expected.

Related to #20.