### PR TITLE
Fix crashes when mapped file line is empty

### DIFF
--- a/win/abst_FileMapped.go
+++ b/win/abst_FileMapped.go
@@ -99,6 +99,9 @@ func (me *FileMapped) ReadLines() []string {
 
 	for i := 0; i < len(lines); i++ {
 		line := lines[i]
+		if len(line) == 0 {
+			continue
+		}
 		if line[len(line)-1] == '\r' {
 			lines[i] = line[:len(line)-1] // trim trailing \r
 		}


### PR DESCRIPTION
I was trying to use `win.IniLoad`.

However, It panic with message: "runtime error: index out of range [-1]".

I found my INI file has empty line, and works after changed that lines.

Thanks.