### PR TITLE
Fix UTF-16 helpers for Go 1.20

### DIFF
--- a/wstr/encoders.go
+++ b/wstr/encoders.go
@@ -63,10 +63,7 @@ func EncodeArrToSlice(strs ...string) []uint16 {
 //	buf := make([]uint16, 10)
 //	wstr.EncodeToBuf(buf, "abc")
 func EncodeToBuf(dest []uint16, s string) int {
-	const (
-		_SURR_SELF   = 0x10000
-		_REPLAC_CHAR = '\uFFFD'
-	)
+	const _SURR_SELF = 0x10000
 
 	szDest := len(dest)
 	if szDest == 0 {
@@ -75,16 +72,17 @@ func EncodeToBuf(dest []uint16, s string) int {
 
 	idx := 0
 EachRune:
+	// Ranging over a string yields valid Unicode scalar values; invalid UTF-8
+	// bytes become U+FFFD, which fits in one UTF-16 word.
 	for _, ch := range s {
 		if idx >= szDest-1 {
 			break // truncate to prevent buffer overrun
 		}
 
-		switch utf16.RuneLen(ch) {
-		case 1: // normal rune
+		if ch < _SURR_SELF { // normal rune
 			dest[idx] = uint16(ch)
 			idx++
-		case 2: // needs surrogate sequence
+		} else { // needs surrogate sequence
 			if idx+1 >= szDest-1 {
 				break EachRune // no room for surrogate pair
 			} else {
@@ -93,9 +91,6 @@ EachRune:
 				dest[idx+1] = uint16(r2)
 				idx += 2
 			}
-		default: // cannot be properly encoded
-			dest[idx] = uint16(_REPLAC_CHAR)
-			idx++
 		}
 	}
 	dest[idx] = 0x0000 // terminating null

--- a/wstr/utils.go
+++ b/wstr/utils.go
@@ -3,7 +3,6 @@ package wstr
 import (
 	"fmt"
 	"strings"
-	"unicode/utf16"
 )
 
 // Returns a new string with the first character converted to uppercase.
@@ -69,14 +68,12 @@ func CountRunes(s string) int {
 // zero.
 func CountUtf16Len(s string) int {
 	numWords := 0
+	// Ranging over a string yields valid Unicode scalar values; invalid UTF-8
+	// bytes become U+FFFD, which fits in one UTF-16 word.
 	for _, ch := range s {
-		switch utf16.RuneLen(ch) {
-		case 2:
+		if ch > '\uffff' {
 			numWords += 2 // surrogate sequence
-		default:
-			// If 1, is an ordinary char.
-			// If -1, it's a rune which cannot be encoded to UTF-16; in such
-			// case, encoding will simply place a '\uFFFD' word.
+		} else {
 			numWords++
 		}
 	}

--- a/wstr/wstr_test.go
+++ b/wstr/wstr_test.go
@@ -2,6 +2,7 @@ package wstr_test
 
 import (
 	"fmt"
+	"testing"
 	"unsafe"
 
 	"github.com/rodrigocfd/windigo/wstr"
@@ -129,6 +130,28 @@ func ExampleCountUtf16Len() {
 	c2 := wstr.CountUtf16Len("🙂")
 	fmt.Println(c1, c2)
 	// Output: 3 2
+}
+
+func TestCountUtf16Len(t *testing.T) {
+	tests := []struct {
+		name string
+		text string
+		want int
+	}{
+		{"empty", "", 0},
+		{"ASCII", "foo", 3},
+		{"BMP", "世界", 2},
+		{"supplementary", "🙂", 2},
+		{"mixed", "A世🙂", 4},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := wstr.CountUtf16Len(tt.text); got != tt.want {
+				t.Fatalf("CountUtf16Len(%q) = %d; want %d", tt.text, got, tt.want)
+			}
+		})
+	}
 }
 
 func ExampleFmtBytes() {

--- a/wstr/wstr_test.go
+++ b/wstr/wstr_test.go
@@ -2,7 +2,6 @@ package wstr_test
 
 import (
 	"fmt"
-	"testing"
 	"unsafe"
 
 	"github.com/rodrigocfd/windigo/wstr"
@@ -126,32 +125,13 @@ func ExampleCountRunes() {
 }
 
 func ExampleCountUtf16Len() {
+	c0 := wstr.CountUtf16Len("")
 	c1 := wstr.CountUtf16Len("foo")
 	c2 := wstr.CountUtf16Len("🙂")
-	fmt.Println(c1, c2)
-	// Output: 3 2
-}
-
-func TestCountUtf16Len(t *testing.T) {
-	tests := []struct {
-		name string
-		text string
-		want int
-	}{
-		{"empty", "", 0},
-		{"ASCII", "foo", 3},
-		{"BMP", "世界", 2},
-		{"supplementary", "🙂", 2},
-		{"mixed", "A世🙂", 4},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			if got := wstr.CountUtf16Len(tt.text); got != tt.want {
-				t.Fatalf("CountUtf16Len(%q) = %d; want %d", tt.text, got, tt.want)
-			}
-		})
-	}
+	c3 := wstr.CountUtf16Len("世界")
+	c4 := wstr.CountUtf16Len("A世🙂")
+	fmt.Println(c0, c1, c2, c3, c4)
+	// Output: 0 3 2 2 4
 }
 
 func ExampleFmtBytes() {


### PR DESCRIPTION
## Problem

The module declares Go 1.20 in `go.mod`, but the `wstr` package calls
`unicode/utf16.RuneLen`, which is unavailable in Go 1.20.

As a result, windigo cannot be compiled with Go 1.20.14:

```text
wstr\encoders.go:83:16: undefined: utf16.RuneLen
wstr\utils.go:73:16: undefined: utf16.RuneLen
```

## Changes

- Replace both `utf16.RuneLen` calls with direct BMP/supplementary-plane checks.
- Preserve the existing UTF-16 encoding behavior.
- Add tests for empty, ASCII, BMP, supplementary-plane, and mixed strings.
- Make no changes to the public API.

A Go string range produces valid Unicode scalar values. Invalid UTF-8 bytes
are represented as U+FFFD, which requires one UTF-16 code unit. Therefore,
the direct BMP check preserves the previous behavior.

## Verification

Tested on Windows with Go 1.20.14:

```text
go version go1.20.14 windows/amd64
go test ./...
go vet ./wstr
```

All tests passed.